### PR TITLE
Minor Updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cleandataframe
 Type: Package
 Title: Dataframe Cleaning and Conversion
-Version: 0.1.1
+Version: 0.2.0
 Author: Harrison Zhu, Haifeng Zhu
 Maintainer: <harrison0zhu@gmail.com>
 Description: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cleandataframe
 Type: Package
 Title: Dataframe Cleaning and Conversion
-Version: 0.1.0
+Version: 0.1.1
 Author: Harrison Zhu, Haifeng Zhu
 Maintainer: <harrison0zhu@gmail.com>
 Description: 

--- a/R/cleandataframe.R
+++ b/R/cleandataframe.R
@@ -159,74 +159,68 @@ clean_dataframe <- function(
   # Check and operate on columns
   col_op <- match.arg(column_operation, choices = c("keep", "remove_empty", "remove_duplicates", "replace_duplicates", "remove_no_name", "remove_incomplete", "replace_no_name"), several.ok = TRUE)
   if (check_column) {
-    if ("keep" %in% col_op) {
-      if (any(duplicated(t(df)))) {
-        cat(paste0("There are some duplicate columns that are present.\n"))
-      }
-    }
-
-    if ("replace_duplicates" %in% col_op) {
-      df[, duplicated(t(df))] <- NA
-    }
-
-    if ("remove_duplicates" %in% col_op) {
-      df <- df[, !duplicated(t(df)), drop = FALSE]
-    }
-
-    if ("replace_no_name" %in% col_op) {
-      no_name <- is.na(names(df)) | grepl("^\\s*$", names(df))
-      df[, no_name] <- NA
-    }
-
-    if ("remove_no_name" %in% col_op) {
-      no_name <- is.na(names(df)) | grepl("^\\s*$", names(df))
-      df <- df[, !no_name, drop = FALSE]
-    }
-
-    if ("remove_incomplete" %in% col_op) {
-      empty_cols <- apply(df, 2, function(col) any(is.na(col) | grepl("^\\s*$", col)))
-      df <- df[, !empty_cols, drop = FALSE]
-    }
-
-    if ("remove_empty" %in% col_op) {
-      empty_cols <- apply(df, 2, function(col) all(is.na(col) | grepl("^\\s*$", col)))
-      df <- df[, !empty_cols, drop = FALSE]
+    for (op in col_op) {
+      switch(op,
+        "keep" = {
+          cat(paste0("There are some duplicate columns that are present.\n"))
+        },
+        "replace_duplicates" = {
+          df[, duplicated(t(df))] <- NA
+        },
+        "remove_duplicates" = {
+          df <- df[, !duplicated(t(df)), drop = FALSE]
+        },
+        "replace_no_name" = {
+          no_name <- is.na(names(df)) | grepl("^\\s*$", names(df))
+          df[, no_name] <- NA
+        },
+        "remove_no_name" = {
+          no_name <- is.na(names(df)) | grepl("^\\s*$", names(df))
+          df <- df[, !no_name, drop = FALSE]
+        },
+        "remove_incomplete" = {
+          empty_cols <- apply(df, 2, function(col) any(is.na(col) | grepl("^\\s*$", col)))
+          df <- df[, !empty_cols, drop = FALSE]
+        },
+        "remove_empty" = {
+          empty_cols <- apply(df, 2, function(col) all(is.na(col) | grepl("^\\s*$", col)))
+          df <- df[, !empty_cols, drop = FALSE]
+        }
+      )
     }
   }
 
   # Check and operate on records (rows)
   rec_op <- match.arg(record_operation, choices = c("keep", "remove_empty", "remove_duplicates", "replace_duplicates", "remove_no_name", "remove_incomplete", "replace_no_name"), several.ok = TRUE)
   if (check_records) {
-    if ("keep" %in% rec_op) {
-      cat(paste0("There are some duplicate records that are present.\n"))
-    }
-    
-    if ("replace_duplicates" %in% rec_op) {
-      df[duplicated(df), ] <- NA
-    }
-
-    if ("remove_duplicates" %in% rec_op) {
-      df <- df[!duplicated(df), , drop = FALSE]
-    }
-    
-    if ("replace_no_name" %in% rec_op) {
-      no_name <- grepl("^\\s*$", names(df))
-      df[, no_name] <- NA
-    }
-
-    if ("remove_no_name" %in% rec_op) {
-      no_name <- grepl("^\\s*$", names(df))
-      df <- df[, !no_name, drop = FALSE]
-    }
-
-    if ("remove_incomplete" %in% rec_op) {
-      empty_rows <- apply(df, 1, function(row) any(is.na(row) | grepl("^\\s*$", col)))
-      df <- df[!empty_rows, , drop = FALSE]
-    }
-
-    if ("remove_empty" %in% rec_op) {
-      empty_rows <- apply(df, 1, function(row) all(is.na(row) | grepl("^\\s*$", col)))
-      df <- df[!empty_rows, , drop = FALSE]
+    for (op in rec_op) {
+      switch(op,
+        "keep" = {
+          cat(paste0("There are some duplicate records that are present.\n"))
+        },
+        "replace_duplicates" = {
+          df[duplicated(df), ] <- NA
+        },
+        "remove_duplicates" = {
+          df <- df[!duplicated(df), , drop = FALSE]
+        },
+        "replace_no_name" = {
+          no_name <- grepl("^\\s*$", rownames(df))
+          df[no_name, ] <- NA
+        },
+        "remove_no_name" = {
+          no_name <- grepl("^\\s*$", rownames(df))
+          df <- df[!no_name, , drop = FALSE]
+        },
+        "remove_incomplete" = {
+          empty_rows <- apply(df, 1, function(row) any(is.na(row) | grepl("^\\s*$", col)))
+          df <- df[!empty_rows, , drop = FALSE]
+        },
+        "remove_empty" = {
+          empty_rows <- apply(df, 1, function(row) all(is.na(row) | grepl("^\\s*$", col)))
+          df <- df[!empty_rows, , drop = FALSE]
+        }
+      )
     }
   }
 

--- a/man/assert_class.Rd
+++ b/man/assert_class.Rd
@@ -16,13 +16,13 @@ logical. Returns \code{TRUE} if the object is of the required class; otherwise, 
 }
 \description{
 Assert that an object inherits from a specified class.
-Checks if the input object inherits from the specified class and throws an error if not.
 }
 \examples{
-# Example: Passes because 1:3 is of class "integer"
+# Example: Passes and returns TRUE because 1:3 is of class "integer"
 assert_class(1:3, "integer")
 
-# Example: Prints warning because 1:3 is not of class "character"
+# Example: Prints warning and returns FALSE because 1:3 is not of the
+# class "character"
 assert_class(1:3, "character")
 
 }

--- a/man/assert_encode.Rd
+++ b/man/assert_encode.Rd
@@ -16,7 +16,7 @@ logical. TRUE if all elements have the required encoding, FALSE otherwise.
 }
 \description{
 Assert that all elements of a character vector have the required encoding.
-Any invalid vectors will cause for an error to be thrown.
+Any non-character or factor vectors will cause for an error to be thrown.
 }
 \examples{
 # All elements are UTF-8 encoded

--- a/man/check_typo.Rd
+++ b/man/check_typo.Rd
@@ -12,6 +12,8 @@ check_typo(
   max_distance = 0.5,
   correct = TRUE,
   correct_method = "replace",
+  correct_spelling = NULL,
+  similarity_cut = 0.25,
   ...
 )
 }
@@ -28,7 +30,11 @@ check_typo(
 
 \item{correct}{logical. A value specifying whether to correct typos. Default is TRUE.}
 
-\item{correct_method}{character. A string specifying the method to use for correction. Default is "replace".
+\item{correct_method}{character. A string specifying the method to use for correction. Default is "replace".}
+
+\item{correct_spelling}{character. A vector containing a list of valid spellings for the vector. Default is \code{NULL}.}
+
+\item{similarity_cut}{numeric. Value between 0 and 1 that determines similarity score needed for two strings to be considered typos. Default is \code{0.25}.
 The different methods are "replace", "remove", "error", and "keep".}
 
 \item{...}{Additional arguments passed to stringdist::stringdistmatrix.}
@@ -38,18 +44,68 @@ A character vector with typos corrected if chosen.
 }
 \description{
 Identifies typos in a vector by clustering similar elements together.
-Typos can be kept, removed, replaced with the most common occurrence, or cause for an error to be thrown.
+A list of the correct spelling can be provided. Otherwise the "correct" spelling is determined
+by the variation of the typo that occurs most frequently.
+Any typos deemed not similar enough to the given correct spellings will be treated as separate words,
+meaning the correct spelling of these typos is assumed to be a word not provided in the correct spellings.
+Typos can be kept, removed, replaced with the most correct spelling, or cause for an error to be thrown.
 Any NA or whitespace elements in character vectors are ignored.
 }
 \examples{
-# Example: Default operation is to replace each typo with its most common occurrence
-check_typo(c("apple", "aple", "appel", "aple","apple","apple","ap ple","Back","Back","b_eck"))
+# Example: Vector with no typos is returned as is.
+check_typo(c("apple", "banana", "cherry"))
+
+# Example: Vector with no typos and spelling provided is returned as is.
+# "cherry" is not part of the correct spelling, but different from "apple"
+# and "banana", so it is not replaced.
+check_typo(
+  c("apple", "banana", "cherry"),
+  correct_spelling = c("apple", "banana")
+)
+
+# Example: Default operation is to replace each typo with its most variation
+# of the correct spelling.
+check_typo(
+  c("apple", "aple", "appel", "aple","apple",
+  "apple","ap ple","Back","Back","b_eck")
+)
+
+# Example: Correct spellings are provided, and typos are matched to
+# different spellings.
+# provided that they are similar enough, and then replaced.
+check_typo(
+  c("applu", "ap pl", "aple", "banan", "anana", "banbanas"),
+  correct_spelling = c("apple", "banana")
+)
+
+# Example: Words are matched to correct spelling and replaced if similar.
+# Words that are not similar to the correct spellings are clustered
+# separately and matched together among themselves.
+check_typo(
+  c("applu", "aple", "anana", "banbanas", "durian", "durian", "duria"),
+  correct_spelling = c("apple", "banana")
+)
 
 # Example: Remove typos while keeping the "correct" spelling,
 # which is the most common occurrence
-check_typo(c("cow", "cowa", "cowch", "cow", "moose", "meese", "meese"), correct_method = "remove")
+check_typo(
+  c("cow", "cowa", "cowch", "cow", "moose", "meese", "meese"),
+  correct_method = "remove"
+)
 
-# Example: Replaces typos with the most common occurrence, which is not "apple" in this case
+# Example: Check if there are anyt typos and keep them.
+check_typo(
+  c("apple", "ap pl", "banana", "orange", "orenge", "apple"),
+  correct_method = "keep"
+)
+
+# Example: Replaces typos with the most common occurrence, which is
+# not "apple" in this case
 # and automatically ignores NA and empty or whitespace strings
 check_typo(c("apple", "ap pl", NA, "apple", "ap pl", "ap pl", " ", "aple"))
+
+# Example: Throw an error if there are any typos present.
+\dontrun{
+check_typo(c("apple", "apple", "ap pl"), correct_method = "error")
+}
 }

--- a/man/clean_vector.Rd
+++ b/man/clean_vector.Rd
@@ -13,24 +13,25 @@ clean_vector(
   encode_required = NULL,
   encode_convert = NULL,
   from_encode = "",
-  validate_non_duplicate_value = FALSE,
-  duplicate_operation = "keep",
-  validate_nonempty_value = FALSE,
-  empty_operation = "keep",
-  sep_in = "[^[:alnum:]]",
-  squeeze_continuous_sep_in = TRUE,
-  remove_initial_and_end_sep_in = TRUE,
   validate_format = FALSE,
   convert_format = FALSE,
   format_pattern = NULL,
   format_case_style = NULL,
-  check_typo = FALSE,
-  correct_typo = FALSE,
-  typo_operation = "replace",
-  sep_out = "_",
   format_decimal_digits = NULL,
   format_require_integer = NULL,
   format_date_format = NULL,
+  check_typo = FALSE,
+  correct_typo = FALSE,
+  correct_spelling = NULL,
+  sep_in = "[^\\\\p{L}\\\\p{N}]",
+  squeeze_continuous_sep_in = TRUE,
+  remove_initial_and_end_sep_in = TRUE,
+  sep_out = "_",
+  typo_operation = "replace",
+  validate_non_duplicate_value = FALSE,
+  duplicate_operation = "keep",
+  validate_nonempty_value = FALSE,
+  empty_operation = "keep",
   ignore_na = TRUE,
   na_value = NA,
   ...
@@ -53,20 +54,6 @@ clean_vector(
 
 \item{from_encode}{character. The encoding to convert from. Default is \code{"UTF-8"}.}
 
-\item{validate_non_duplicate_value}{logical. Whether to check for duplicate values. Default is \code{TRUE}.}
-
-\item{duplicate_operation}{character. Operation to perform if duplicates are found. One of \code{"keep"}, \code{"keep_first"}, \code{"keep_last"}, \code{"replace"}, or \code{"error"}. Default is \code{"keep"}.}
-
-\item{validate_nonempty_value}{logical. Whether to check for empty values (\code{NA} or \code{""}). Default is \code{TRUE}.}
-
-\item{empty_operation}{character. Operation to perform if empty values are found. One of \code{"keep"}, \code{"remove"}, \code{"replace"}, or \code{"error"}. Default is \code{"keep"}.}
-
-\item{sep_in}{character. Regular expression for splitting words when converting case style. Default is \code{"[^[:alnum:]]"}.}
-
-\item{squeeze_continuous_sep_in}{logical. Whether to squeeze multiple consecutive separators in \code{sep_in} to a single separator. Default is \code{TRUE}.}
-
-\item{remove_initial_and_end_sep_in}{logical. Whether to remove separators at the start or end of the string when converting case style. Default is \code{TRUE}.}
-
 \item{validate_format}{logical. Whether to validate the format of the vector (e.g., regex for character, decimal digits for numeric, date format for dates). Default is \code{FALSE}.}
 
 \item{convert_format}{logical. Whether to convert the format to the vector to the specified parameters. Default is \code{FALSE}.}
@@ -75,19 +62,35 @@ clean_vector(
 
 \item{format_case_style}{character. String specifying the case style to enforce or convert to (e.g., "lower", "upper", "title", "snake", etc.). Default is \code{NULL}.}
 
-\item{check_typo}{logical. Whether to check for typos in character/factor vectors. Default is \code{TRUE}.}
-
-\item{correct_typo}{logical. Whether to correct typos if found. Default is \code{FALSE}.}
-
-\item{typo_operation}{character. Operation to perform if typos are found. One of \code{"keep"}, \code{"remove"}, \code{"replace"}, or \code{"error"}. Default is \code{"keep"}.}
-
-\item{sep_out}{character. Separator to use when joining words after case conversion. Default is \code{"_"}.}
-
 \item{format_decimal_digits}{integer. Number of decimal digits required for numeric vectors. Default is \code{NULL}.}
 
 \item{format_require_integer}{logical. If \code{TRUE}, require integer values for numeric vectors. Default is \code{NULL}.}
 
 \item{format_date_format}{character string specifying the date format for date/time vectors. Default is \code{NULL}.}
+
+\item{check_typo}{logical. Whether to check for typos in character/factor vectors. Default is \code{TRUE}.}
+
+\item{correct_typo}{logical. Whether to correct typos if found. Default is \code{FALSE}.}
+
+\item{correct_spelling}{character. A vector containing a list of valid spellings for the vector. Default is \code{NULL}.}
+
+\item{sep_in}{character. Regular expression for splitting words when converting case style. Default is \code{"[^\\p{L}\\]{N}]"}.}
+
+\item{squeeze_continuous_sep_in}{logical. Whether to squeeze multiple consecutive separators in \code{sep_in} to a single separator. Default is \code{TRUE}.}
+
+\item{remove_initial_and_end_sep_in}{logical. Whether to remove separators at the start or end of the string when converting case style. Default is \code{TRUE}.}
+
+\item{sep_out}{character. Separator to use when joining words after case conversion. Default is \code{"_"}.}
+
+\item{typo_operation}{character. Operation to perform if typos are found. One of \code{"keep"}, \code{"remove"}, \code{"replace"}, or \code{"error"}. Default is \code{"keep"}.}
+
+\item{validate_non_duplicate_value}{logical. Whether to check for duplicate values. Default is \code{TRUE}.}
+
+\item{duplicate_operation}{character. Operation to perform if duplicates are found. One of \code{"keep"}, \code{"keep_first"}, \code{"keep_last"}, \code{"replace"}, or \code{"error"}. Default is \code{"keep"}.}
+
+\item{validate_nonempty_value}{logical. Whether to check for empty values (\code{NA} or \code{""}). Default is \code{TRUE}.}
+
+\item{empty_operation}{character. Operation to perform if empty values are found. One of \code{"keep"}, \code{"remove"}, \code{"replace"}, or \code{"error"}. Default is \code{"keep"}.}
 
 \item{ignore_na}{logical. For character/factor vectors, whether to ignore NA values. Default is \code{TRUE}.}
 

--- a/man/convert_format.Rd
+++ b/man/convert_format.Rd
@@ -9,7 +9,7 @@ convert_format(
   regex_pattern = NULL,
   ignore_na = TRUE,
   case_style = NULL,
-  sep_in = "[^[:alnum:]]",
+  sep_in = "[^\\\\p{L}\\\\]{N}]",
   sep_out = "_",
   decimal_digits = NULL,
   require_integer = NULL,

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,18 +1,18 @@
 ---
-title: "getting-started"
+title: "Getting Started"
 author: "Harrison Zhu"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{getting-started}
+  %\VignetteIndexEntry{Getting Started}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
 # Introduction
 
-This demonstrates how to utilize the functionalities of the `cleandataframe` to
-clean and validate data in a vector or data frame.
+This vignette demonstrates how to utilize the functionalities of the
+`cleandataframe` package to clean and validate data in a vector or data frame.
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
@@ -24,6 +24,8 @@ knitr::opts_chunk$set(
 ```{r setup}
 library(cleandataframe)
 ```
+
+
 
 # Cleaning a Character Vector
 
@@ -42,7 +44,7 @@ To perform the following operations on `vector1`:
 - Check/assert the class of the vector is initially `"character"` using `assert_class`
 - Check/assert the encoding of the vector is initially `"UTF-8"` using `assert_encode`
 - Convert the encoding of the vector to `"latin1"` using `convert_encode`
-- Check/assert the formatting of the string is only letters in the english alphabet or empty using `assert_format`
+- Check/assert the formatting of the string is only letters with the `"[\p{L}]"` regex pattern using `assert_format`
 - Convert the formatting to only letters in the english alphabet or empty, replace invalid conversions with `"NA"` using `convert_format`
 - Check for typos and replace them with the most common occurrence using `check_typo`
 - Check for duplicate values in the vector
@@ -50,7 +52,7 @@ To perform the following operations on `vector1`:
 - Check for empty values and remove them
   - Can only be done using `clean_vector`
 
-Each function can be called separately.
+Each function can be called separately, though this is not the suggested approach.
 
 ```{r}
 # Copy of vector1 to run example without running previous code
@@ -59,8 +61,8 @@ vector1 <- c("café", "apple", NA, "apple", "aple", "NA", "brick", "blick", "cow
 assert_class(vector1, required_class = "character")
 assert_encode(vector1, required_encode = "UTF-8")
 vector1 <- convert_encode(vector1, required_encode = "latin1", from_encode = "UTF-8")
-assert_format(vector1, regex_pattern = "^[A-Za-z]*$")
-vector1 <- convert_format(vector1, regex_pattern = "^[A-Za-z]*$", na_value = "NA")
+assert_format(vector1, regex_pattern = "^[\\p{L}]*$")
+vector1 <- convert_format(vector1, regex_pattern = "^[\\p{L}]*$", na_value = "NA")
 vector1 <- check_typo(vector1, correct_method = "replace")
 vector1 <- clean_vector(vector1, validate_non_duplicate_value = TRUE, validate_nonempty_value = TRUE, empty_operation = "remove", na_value = "NA")
 
@@ -83,7 +85,7 @@ vector1 <- clean_vector(
   encode_convert = "latin1",
   validate_format = TRUE,
   convert_format = TRUE,
-  format_pattern = "^[A-Za-z]*$",
+  format_pattern = "^[\\p{L}]*$",
   check_typo = TRUE,
   correct_typo = TRUE,
   typo_operation = "replace",
@@ -207,23 +209,25 @@ Similarly to `clean_vector`, `clean_dataframe` also has an order of operations:
 4. Converting the record name format in `rowname_pattern`
 5. Calling `clean_vector` on each column with the parameters listed in `clean_column_args`
 6. Performing the specified operations on each column in `column_operation`
-  - Before other operations are performed, `"keep"` checks for duplicates, this does not stop other operations from being performed
-  - Operations that check and alter duplicate values are first, then ones with no name, then incomplete columns, and lastly empty columns
-  - Replace operations are performed before their corresponding remove operations
+  - Operations performed are done in index order of the vector containing the column operations
 7. Performing the specified operations on each record in `record_operation`
-  - Before other operations are performed, `"keep"` checks for duplicates, this does not stop other operations from being performed
-  - Operations that check and alter duplicate values are first, then ones with no name, then incomplete rows, and lastly empty rows
-  - Replace operations are performed before their corresponding remove operations
+  - Operations performed are done in index order of the vector containing the record operations
 8. Whitespace is replaced by `NA` values
-
-There may be occurrences where the built-in order of operations may not bring about
-the desired result. Thus, multiple function calls are needed to complete the desired
-operations.
 
 Using the same data frame from the previous example, removing all the empty columns and
 records and then replacing duplicates will not work with one function call. Instead it
 returns a data frame with the duplicates also removed as the replacement is done before
 the removal of empty columns and records as shown below.
+
+Expanding more on the order of record and column operations, they are performed based in
+order by index value. As in, operations are done starting from the first operation at index
+1, then index 2, and so on until all operations have been performed.
+
+For example, if a user wanted to remove all the empty columns and records and then replace
+duplicate values, they would use the `"remove_empty"` operation first, then the
+`"replace_duplicates"` operation. If the order were swapped, duplicates would be replaced
+first, then empty columns and records would be removed, which would include the replaced
+duplicates and cause unwanted behavior.
 
 ```{r}
 # Copy of df to run example without running previous code
@@ -239,40 +243,9 @@ names(df)[4] <- "names"
 df <- clean_dataframe(
   df,
   check_column = TRUE,
-  column_operation = c("replace_duplicates", "remove_empty"),
+  column_operation = c("remove_empty", "replace_duplicates"),
   check_records = TRUE,
-  record_operation = c("replace_duplicates", "remove_empty")
-)
-
-df
-```
-
-Two separate function calls are needed in order to get the desired results as shown below.
-
-```{r}
-df <- data.frame(
-  names = c("Alice", "Bob", "Collin", "Donna", "Ethan", NA, "Bob"),
-  AGE = c(20, 23, 28, 20, 25, NA, 23),
-  FavoriteColor = c("red", "green", "yellow", "blue", "orange", NA, "green"),
-  names_dup = c("Alice", "Bob", "Collin", "Donna", "Ethan", NA, "Bob"),
-  height = c(NA, NA, NA, NA, NA, NA, NA)
-)
-names(df)[4] <- "names"
-
-df <- clean_dataframe(
-  df,
-  check_column = TRUE,
-  column_operation = "remove_empty",
-  check_records = TRUE,
-  record_operation = "remove_empty"
-)
-
-df <- clean_dataframe(
-  df,
-  check_column = TRUE,
-  column_operation = "replace_duplicates",
-  check_records = TRUE,
-  record_operation = "replace_duplicates"
+  record_operation = c("remove_empty", "replace_duplicates")
 )
 
 df


### PR DESCRIPTION
- added the option to provide a vector containing correct spelling to correct_typo, which then matches typos to the correct spelling if similar enough
-  allowed for column and record operations to be done in order in which they were input in the vector rather than having a determined order built in, which caused for extra function calls
-  minor fixes and edits to documentation